### PR TITLE
Fix error in GDScript version

### DIFF
--- a/addons/TrailRenderer/Runtime/GD/trail_renderer.gd
+++ b/addons/TrailRenderer/Runtime/GD/trail_renderer.gd
@@ -17,8 +17,7 @@ func _enter_tree() -> void:
 
 func _process(delta: float) -> void:
 	if not _is_emitting_last_frame and is_emitting:
-		var trail_piece: TrailPiece = _trail_pieces[0]
-		if _trail_pieces.size() == 0 or trail_piece.is_dirty():
+		if _trail_pieces.size() == 0 or _trail_pieces[0].is_dirty():
 			_trail_pieces.insert(0, TrailPiece.new(self))
 	_is_emitting_last_frame = is_emitting
 


### PR DESCRIPTION
The original code threw an error if the trail hasn't been emitting long enough for all segments to clear. It accessed the first trail piece before checking if it existed